### PR TITLE
FIX: AppInsight agent install changes machine's powershell execution policy

### DIFF
--- a/Samples/AzureEmailService/MvcWebRole/AppInsightsAgent/InstallAgent.bat
+++ b/Samples/AzureEmailService/MvcWebRole/AppInsightsAgent/InstallAgent.bat
@@ -19,21 +19,19 @@ REM Log the environment variables
 ECHO ApplicationInsightsAgent.DownloadLink=%ApplicationInsightsAgent.DownloadLink% >> "%ROLEROOT%\install.agent.info.log" 2>&1
 ECHO RoleEnvironment.IsEmulated=%RoleEnvironment.IsEmulated% >> "%ROLEROOT%\install.agent.info.log" 2>&1
 
+REM Log current Execution policy
+FOR /F "usebackq" %%i IN (`powershell -noprofile -command "Get-ExecutionPolicy"`) DO (
+    ECHO Powershell.ExecutionPolicy=%%i >> "%ROLEROOT%\install.agent.info.log" 2>&1
+)
+
 ECHO ................................................ >> "%ROLEROOT%\install.agent.info.log" 2>&1
 
 REM Following sets appropriate execution policy on the host machine
 SET ExecutionPolicyLevel=RemoteSigned
-FOR /F "usebackq" %%i IN (`powershell -noprofile -command "Get-ExecutionPolicy"`) DO (
-    SET ExecutionPolicy=%%i
-    IF /I "%%i"=="Unrestricted" GOTO :InstallAgent
-    IF /I "%%i"=="RemoteSigned" GOTO :InstallAgent
-    Powershell.exe -NoProfile -Command "Set-ExecutionPolicy RemoteSigned" < NUL >> NUL 2>> NUL
-)
-
-:InstallAgent
 
 ECHO %DATE% %TIME% - Start powershell InstallAgent.ps1 >> "%ROLEROOT%\install.agent.info.log" 2>&1
-Powershell.exe -NoProfile -Command "& '%~dp0InstallAgent.ps1'" < NUL >> NUL 2>> NUL
+Powershell.exe -NoProfile -ExecutionPolicy %ExecutionPolicyLevel% -Command "& '%~dp0InstallAgent.ps1'" < NUL >> NUL 2>> NUL
+
 IF %ERRORLEVEL% EQU 0 (
     ECHO %DATE% %TIME% - Completed executing InstallAgent.ps1 normally. >> "%ROLEROOT%\install.agent.info.log" 2>&1
 ) ELSE (

--- a/Samples/AzureEmailService/WorkerRoleA/AppInsightsAgent/InstallAgent.bat
+++ b/Samples/AzureEmailService/WorkerRoleA/AppInsightsAgent/InstallAgent.bat
@@ -19,21 +19,19 @@ REM Log the environment variables
 ECHO ApplicationInsightsAgent.DownloadLink=%ApplicationInsightsAgent.DownloadLink% >> "%ROLEROOT%\install.agent.info.log" 2>&1
 ECHO RoleEnvironment.IsEmulated=%RoleEnvironment.IsEmulated% >> "%ROLEROOT%\install.agent.info.log" 2>&1
 
+REM Log current Execution policy
+FOR /F "usebackq" %%i IN (`powershell -noprofile -command "Get-ExecutionPolicy"`) DO (
+    ECHO Powershell.ExecutionPolicy=%%i >> "%ROLEROOT%\install.agent.info.log" 2>&1
+)
+
 ECHO ................................................ >> "%ROLEROOT%\install.agent.info.log" 2>&1
 
 REM Following sets appropriate execution policy on the host machine
 SET ExecutionPolicyLevel=RemoteSigned
-FOR /F "usebackq" %%i IN (`powershell -noprofile -command "Get-ExecutionPolicy"`) DO (
-    SET ExecutionPolicy=%%i
-    IF /I "%%i"=="Unrestricted" GOTO :InstallAgent
-    IF /I "%%i"=="RemoteSigned" GOTO :InstallAgent
-    Powershell.exe -NoProfile -Command "Set-ExecutionPolicy RemoteSigned" < NUL >> NUL 2>> NUL
-)
-
-:InstallAgent
 
 ECHO %DATE% %TIME% - Start powershell InstallAgent.ps1 >> "%ROLEROOT%\install.agent.info.log" 2>&1
-Powershell.exe -NoProfile -Command "& '%~dp0InstallAgent.ps1'" < NUL >> NUL 2>> NUL
+Powershell.exe -NoProfile -ExecutionPolicy %ExecutionPolicyLevel% -Command "& '%~dp0InstallAgent.ps1'" < NUL >> NUL 2>> NUL
+
 IF %ERRORLEVEL% EQU 0 (
     ECHO %DATE% %TIME% - Completed executing InstallAgent.ps1 normally. >> "%ROLEROOT%\install.agent.info.log" 2>&1
 ) ELSE (

--- a/Samples/AzureEmailService/WorkerRoleB/AppInsightsAgent/InstallAgent.bat
+++ b/Samples/AzureEmailService/WorkerRoleB/AppInsightsAgent/InstallAgent.bat
@@ -19,21 +19,19 @@ REM Log the environment variables
 ECHO ApplicationInsightsAgent.DownloadLink=%ApplicationInsightsAgent.DownloadLink% >> "%ROLEROOT%\install.agent.info.log" 2>&1
 ECHO RoleEnvironment.IsEmulated=%RoleEnvironment.IsEmulated% >> "%ROLEROOT%\install.agent.info.log" 2>&1
 
+REM Log current Execution policy
+FOR /F "usebackq" %%i IN (`powershell -noprofile -command "Get-ExecutionPolicy"`) DO (
+    ECHO Powershell.ExecutionPolicy=%%i >> "%ROLEROOT%\install.agent.info.log" 2>&1
+)
+
 ECHO ................................................ >> "%ROLEROOT%\install.agent.info.log" 2>&1
 
 REM Following sets appropriate execution policy on the host machine
 SET ExecutionPolicyLevel=RemoteSigned
-FOR /F "usebackq" %%i IN (`powershell -noprofile -command "Get-ExecutionPolicy"`) DO (
-    SET ExecutionPolicy=%%i
-    IF /I "%%i"=="Unrestricted" GOTO :InstallAgent
-    IF /I "%%i"=="RemoteSigned" GOTO :InstallAgent
-    Powershell.exe -NoProfile -Command "Set-ExecutionPolicy RemoteSigned" < NUL >> NUL 2>> NUL
-)
-
-:InstallAgent
 
 ECHO %DATE% %TIME% - Start powershell InstallAgent.ps1 >> "%ROLEROOT%\install.agent.info.log" 2>&1
-Powershell.exe -NoProfile -Command "& '%~dp0InstallAgent.ps1'" < NUL >> NUL 2>> NUL
+Powershell.exe -NoProfile -ExecutionPolicy %ExecutionPolicyLevel% -Command "& '%~dp0InstallAgent.ps1'" < NUL >> NUL 2>> NUL
+
 IF %ERRORLEVEL% EQU 0 (
     ECHO %DATE% %TIME% - Completed executing InstallAgent.ps1 normally. >> "%ROLEROOT%\install.agent.info.log" 2>&1
 ) ELSE (


### PR DESCRIPTION
The fix modifies InstallAgent.bat to run powershell command with execution policy that required to install AppInsights agent and do not modify machine execution policy.(Issue https://github.com/Microsoft/ApplicationInsights-Home/issues/36)