### PR TITLE
Allow script to run on PowerShell 3

### DIFF
--- a/API/CreateReleaseAnnotation.ps1
+++ b/API/CreateReleaseAnnotation.ps1
@@ -80,7 +80,7 @@ function CreateAnnotation($grpEnv)
 
 # Need powershell version 3 or greater for script to run
 $minimumPowershellMajorVersion = 3
-if ($PSVersionTable.PSVersion.Major -le $minimumPowershellMajorVersion) {
+if ($PSVersionTable.PSVersion.Major -lt $minimumPowershellMajorVersion) {
    Write-Host "Need powershell version $minimumPowershellMajorVersion or greater to create release annotation"
    return
 }


### PR DESCRIPTION
Little tweak from `-le` to `-lt` to allow script to run on PowerShell 3.

This script was failing to run our Windows Server 2012 Standard build server with the `"Need powershell version ..."` error message despite having PowerShell 3 installed. Before upgrading to version 4, I made this quick tweak (which then ran successfully).

Apologies if the commit message is not formatted appropriately.