### PR TITLE
Add optional param: eventDateTime, for past events

### DIFF
--- a/API/CreateReleaseAnnotation.ps1
+++ b/API/CreateReleaseAnnotation.ps1
@@ -4,7 +4,7 @@ param(
     [parameter(Mandatory = $true)][string]$apiKey,
     [parameter(Mandatory = $true)][string]$releaseName,
     [parameter(Mandatory = $false)]$releaseProperties,
-    [parameter(Mandatory = $false)]$eventDateTime
+    [parameter(Mandatory = $false)][DateTime]$eventDateTime
 )
 
 # background info on how fwlink works: After you submit a web request, many sites redirect through a series of intermediate pages before you finally land on the destination page.
@@ -95,7 +95,14 @@ $requestBody.AnnotationName = $releaseName
 if ($eventDateTime -eq $null) {
     $requestBody.EventTime = $currentTime.GetDateTimeFormats("s")[0] # GetDateTimeFormats returns an array 
 } else {
-    $requestBody.EventTime = $eventDateTime # format example: "2016-05-12T09:23:44"
+    # input must be between NOW and 90 days back maximum
+    $maxDaysBack = $currentTime.AddDays(-90)
+    if ($eventDateTime -lt $maxDaysBack -Or $eventDateTime -gt $currentTime) {
+        $output = "-eventDateTime value must be between NOW and 90 days back maximum"
+        throw $output
+    }
+    
+    $requestBody.EventTime = $eventDateTime.GetDateTimeFormats("s")[0]
 }
 $requestBody.Category = "Deployment"
 

--- a/API/CreateReleaseAnnotation.ps1
+++ b/API/CreateReleaseAnnotation.ps1
@@ -1,9 +1,10 @@
-# Sample usage .\CreateReleaseAnnotation.ps1 -applicationId "<appId>" -apiKey "<apiKey>" -releaseName "<releaseName>" -releaseProperties @{"ReleaseDescription"="Release with annotation";"TriggerBy"="John Doe"}
+# Sample usage .\CreateReleaseAnnotation.ps1 -applicationId "<appId>" -apiKey "<apiKey>" -releaseName "<releaseName>" -releaseProperties @{"ReleaseDescription"="Release with annotation";"TriggerBy"="John Doe"} -eventDateTime "2016-07-07T06:23:44"
 param(
     [parameter(Mandatory = $true)][string]$applicationId,
     [parameter(Mandatory = $true)][string]$apiKey,
     [parameter(Mandatory = $true)][string]$releaseName,
-    [parameter(Mandatory = $false)]$releaseProperties
+    [parameter(Mandatory = $false)]$releaseProperties,
+    [parameter(Mandatory = $false)]$eventDateTime
 )
 
 # background info on how fwlink works: After you submit a web request, many sites redirect through a series of intermediate pages before you finally land on the destination page.
@@ -91,7 +92,11 @@ set-variable -Name requestBody -Force -Scope Script
 $requestBody = @{}
 $requestBody.Id = [GUID]::NewGuid()
 $requestBody.AnnotationName = $releaseName
-$requestBody.EventTime = $currentTime.GetDateTimeFormats("s")[0] # GetDateTimeFormats returns an array
+if ($eventDateTime -eq $null) {
+    $requestBody.EventTime = $currentTime.GetDateTimeFormats("s")[0] # GetDateTimeFormats returns an array 
+} else {
+    $requestBody.EventTime = $eventDateTime # format example: "2016-05-12T09:23:44"
+}
 $requestBody.Category = "Deployment"
 
 if ($releaseProperties -eq $null) {


### PR DESCRIPTION
In my case i wanted to back-fill deployment annotations for last 3 months, so this change allows to do that.
Parameter is optional so its backwards compatible.

and, thanks for the script! :)

Dima