### PR TITLE
minor changes and clarifications in the fallback options

### DIFF
--- a/Correlation/Experimental/HttpRequestCorrelationSpec.md
+++ b/Correlation/Experimental/HttpRequestCorrelationSpec.md
@@ -66,7 +66,7 @@ There are three types of operations that can be made with the `Request-Id`:
     Request-Id = `3qdi2JDFioDFjDSF223f23`
     Extend(Request-Id) = `3qdi2JDFioDFjDSF223f23.0`.
 
-- **Increment**: used to mark the "next" call to the dependant service.
+- **Increment**: used to mark the "next" call to the dependant service. Increments that number after the last `.` in base10.
     Request-Id = `3qdi2JDFioDFjDSF223f23-SdfD8DF908D.3`
     Increment(Request-Id) = `3qdi2JDFioDFjDSF223f23-SdfD8DF908D.4`
 


### PR DESCRIPTION
@vancem @lmolkova @jacpull 

- returned back to 128 long header. First - 128 already can handle the depth of 11 levels even with entropy. Second - Application Insights has a limit of 128 characters for ID today.
- clarifications on fallback options
- minor changes