### PR TITLE
Update length of referrer field to 2048 characters

### DIFF
--- a/EndpointSpecs/Schemas/Bond/PageViewData.bond
+++ b/EndpointSpecs/Schemas/Bond/PageViewData.bond
@@ -19,7 +19,7 @@ struct PageViewData
     [Description("Identifier of a page view instance. Used for correlation between page view and other telemetry items.")]
     50: string 	 id;
     
-    [MaxStringLength("1024")]
+    [MaxStringLength("2048")]
     [Description("Fully qualified page URI or URL of the referring page; if unknown, leave blank.")]
     50: string 	 referrerUri;
 }

--- a/EndpointSpecs/Schemas/Docs/PageViewData.md
+++ b/EndpointSpecs/Schemas/Docs/PageViewData.md
@@ -58,7 +58,7 @@ An instance of PageView represents a generic action on a page like a button clic
 
     Fully qualified page URI or URL of the referring page; if unknown, leave blank.
     
-    Max length: 1024
+    Max length: 2048
 
     This field is optional.
     


### PR DESCRIPTION
Updating size for referrer Uri. It makes it consistent with current field "url" size in terms of field size given uris are supersets of urls.