### PR TITLE
Add 'metricNamespace' field to Metrics.

### DIFF
--- a/EndpointSpecs/Schemas/Bond/DataPoint.bond
+++ b/EndpointSpecs/Schemas/Bond/DataPoint.bond
@@ -5,6 +5,10 @@ namespace AI
 [Description("Metric data single measurement.")]
 struct DataPoint
 {
+    [Description("Namespace of the metric.")]
+    [MaxStringLength("256")]
+    5:  string 	           metricNamespace;
+    
     [Description("Name of the metric.")]
     [MaxStringLength("1024")]
     10: required string 	 name;

--- a/EndpointSpecs/Schemas/Docs/MetricData.md
+++ b/EndpointSpecs/Schemas/Docs/MetricData.md
@@ -14,6 +14,14 @@ An instance of the Metric item is a list of measurements (single data points) an
     
     [DataPoint] "Metric data single measurement."
     
+    1. **metricNamespace** : string
+    
+        Namespace of the metric.
+        
+        This field is optional.
+        
+        Max length: 256
+    
     1. **name** : string
     
         Name of the metric.


### PR DESCRIPTION
This is in the context of:
https://github.com/Microsoft/ApplicationInsights-dotnet/issues/759