### PR TITLE
Reserve sdk names for application insights profilers

### DIFF
--- a/EndpointSpecs/SDK-VERSIONS.md
+++ b/EndpointSpecs/SDK-VERSIONS.md
@@ -178,12 +178,19 @@ Snapshot Debugger (Microsoft.ApplicationInsights.SnapshotCollector)
 
 Nuget: https://www.nuget.org/packages/Microsoft.ApplicationInsights.SnapshotCollector
 
-### w_ap, l_ap
-Application Insights Profiler for Windows/Linux.
+### ap
+Application Insights Profiler: Getting call traces, diagnose application performance.
 
-Repro: https://github.com/Microsoft/ApplicationInsights-Profiler-AspNetCore
+Repo: https://github.com/Microsoft/ApplicationInsights-Profiler-AspNetCore
 
 Nuget: https://www.nuget.org/packages/Microsoft.ApplicationInsights.Profiler.AspNetCore
 
 ### hockeysdk
 
+## Prefixes
+Define the prefixes for the SDK.
+
+| SDK Name | Prefix | Description                         |
+|----------|:------:|-------------------------------------|
+| ap       |   w_   | Telemetry from **Windows** Platform |
+| ap       |   l_   | Telemetry from **Linux** Platform   |

--- a/EndpointSpecs/SDK-VERSIONS.md
+++ b/EndpointSpecs/SDK-VERSIONS.md
@@ -178,5 +178,12 @@ Snapshot Debugger (Microsoft.ApplicationInsights.SnapshotCollector)
 
 Nuget: https://www.nuget.org/packages/Microsoft.ApplicationInsights.SnapshotCollector
 
+### w_ap, l_ap
+Application Insights Profiler for Windows/Linux.
+
+Repro: https://github.com/Microsoft/ApplicationInsights-Profiler-AspNetCore
+
+Nuget: https://www.nuget.org/packages/Microsoft.ApplicationInsights.Profiler.AspNetCore
+
 ### hockeysdk
 


### PR DESCRIPTION
We will use ap as our sdk name; we use w & l as prefixes to distinguish the platform we supported at this point by different implementations of the SDKs.