### PR TITLE
Add heartbeat to the list of known sdk versions

### DIFF
--- a/EndpointSpecs/SDK-VERSIONS.md
+++ b/EndpointSpecs/SDK-VERSIONS.md
@@ -155,6 +155,11 @@ metric aggregation pipeline reported this metric. Second implementation
 
 Public versions: https://github.com/Microsoft/ApplicationInsights-dotnet/releases
 
+### hbeat
+Heartbeat telemetry sent in intervals reported this metric item
+
+Public versions: https://github.com/Microsoft/ApplicationInsights-dotnet/releases
+
 ### node
 node.js SDK.
 


### PR DESCRIPTION
Follow up from PR Microsoft/ApplicationInsights-dotnet#782

Add the new SDK version for heartbeat specific metrics sent to the list of known internal SDK version identifiers.
