### PR TITLE
Shorten heartbeat internal sdk id

### DIFF
--- a/EndpointSpecs/SDK-VERSIONS.md
+++ b/EndpointSpecs/SDK-VERSIONS.md
@@ -155,7 +155,7 @@ metric aggregation pipeline reported this metric. Second implementation
 
 Public versions: https://github.com/Microsoft/ApplicationInsights-dotnet/releases
 
-### hbeat
+### hb
 Heartbeat telemetry sent in intervals reported this metric item
 
 Public versions: https://github.com/Microsoft/ApplicationInsights-dotnet/releases

--- a/EndpointSpecs/SDK-VERSIONS.md
+++ b/EndpointSpecs/SDK-VERSIONS.md
@@ -155,8 +155,8 @@ metric aggregation pipeline reported this metric. Second implementation
 
 Public versions: https://github.com/Microsoft/ApplicationInsights-dotnet/releases
 
-### hb
-Heartbeat telemetry sent in intervals reported this metric item
+### hbnet
+Heartbeat telemetry sent in intervals reported this metric item for the dotnet SDK
 
 Public versions: https://github.com/Microsoft/ApplicationInsights-dotnet/releases
 


### PR DESCRIPTION
No reason to have a longer name stored for the internal SDK id for Heartbeats (as pointed out by @cijothomas) Let's make it as short as possible.