### PR TITLE
Updates for schema from the latest internal schema

### DIFF
--- a/EndpointSpecs/Schemas/Bond/ContextTagKeys.bond
+++ b/EndpointSpecs/Schemas/Bond/ContextTagKeys.bond
@@ -37,6 +37,18 @@ struct ContextTagKeys
     [MaxStringLength("46")]
     200: string 	 LocationIp = "ai.location.ip";
     
+    [Description("The country of the client device. If any of Country, Province, or City is specified, those values will be preferred over geolocation of the IP address field. Information in the location context fields is always about the end user. When telemetry is sent from a service, the location context is about the user that initiated the operation in the service.")]
+    [MaxStringLength("256")]
+    201: string 	 LocationCountry = "ai.location.country";
+    
+    [Description("The province/state of the client device. If any of Country, Province, or City is specified, those values will be preferred over geolocation of the IP address field. Information in the location context fields is always about the end user. When telemetry is sent from a service, the location context is about the user that initiated the operation in the service.")]
+    [MaxStringLength("256")]
+    202: string 	 LocationProvince = "ai.location.province";
+    
+    [Description("The city of the client device. If any of Country, Province, or City is specified, those values will be preferred over geolocation of the IP address field. Information in the location context fields is always about the end user. When telemetry is sent from a service, the location context is about the user that initiated the operation in the service.")]
+    [MaxStringLength("256")]
+    203: string 	 LocationCity = "ai.location.city";
+    
     [Description("A unique identifier for the operation instance. The operation.id is created by either a request or a page view. All other telemetry sets this to the value for the containing request or page view. Operation.id is used for finding all the telemetry items for a specific operation instance.")]
     [MaxStringLength("128")]
     300: string 	 OperationId = "ai.operation.id";

--- a/EndpointSpecs/Schemas/Bond/Envelope.bond
+++ b/EndpointSpecs/Schemas/Bond/Envelope.bond
@@ -38,6 +38,10 @@ struct Envelope
     [MaxStringLength("40")]
     60: string 	 iKey;
     
+    [Description("A collection of values bit-packed to represent how the event was processed. Currently represents whether IP address needs to be stripped out from event (set 0x200000) or should be preserved.")]
+    [Name("TelemetryProperties")]
+    70: int64 	 flags;
+    
     [Name("Tags")]
     [TypeAlias("ContextTagKeys")]
     [Description("Key/value collection of context properties. See ContextTagKeys for information on available properties.")]

--- a/EndpointSpecs/Schemas/Bond/MessageData.bond
+++ b/EndpointSpecs/Schemas/Bond/MessageData.bond
@@ -22,4 +22,8 @@ struct MessageData
     [MaxValueLength("8192")]
     100: map<string, string> 	 properties;
     
+    [Description("Collection of custom measurements.")]
+    [MaxKeyLength("150")]
+    200: map<string, double> 	 measurements;
+    
 }

--- a/EndpointSpecs/Schemas/Bond/PageViewData.bond
+++ b/EndpointSpecs/Schemas/Bond/PageViewData.bond
@@ -16,7 +16,8 @@ struct PageViewData
     20: string 	 duration;
     
     [MaxStringLength("128")]
+    [ActAsRequired("Required field for correct correlation.")]
     [Description("Identifier of a page view instance. Used for correlation between page view and other telemetry items.")]
-    50: string 	 id;
+    50: required string 	 id;
     
 }

--- a/EndpointSpecs/Schemas/Bond/PageViewData.bond
+++ b/EndpointSpecs/Schemas/Bond/PageViewData.bond
@@ -15,6 +15,11 @@ struct PageViewData
     [Description("Request duration in format: DD.HH:MM:SS.MMMMMM. For a page view (PageViewData), this is the duration. For a page view with performance information (PageViewPerfData), this is the page load time. Must be less than 1000 days.")]
     20: string 	 duration;
     
+    [Description("Fully qualified page URI or URL of the referring page; if unknown, leave blank")]
+    [ActAsRequired("Field for referrerUri for pageView")]
+    [MaxStringLength("2048")]
+    30: required string 	 referrerUri;
+    
     [MaxStringLength("128")]
     [ActAsRequired("Required field for correct correlation.")]
     [Description("Identifier of a page view instance. Used for correlation between page view and other telemetry items.")]

--- a/EndpointSpecs/Schemas/Bond/RemoteDependencyData.bond
+++ b/EndpointSpecs/Schemas/Bond/RemoteDependencyData.bond
@@ -27,7 +27,7 @@ struct RemoteDependencyData
     61: required string 	 duration;
     
     [Description("Indication of successfull or unsuccessfull call.")]
-    120: nullable<bool> 	 success = true;
+    120: bool 	 success = true;
     
     [MaxStringLength("8192")]
     [Description("Command initiated by this dependency call. Examples are SQL statement and HTTP URL's with all query parameters.")]

--- a/EndpointSpecs/Schemas/Bond/RequestData.bond
+++ b/EndpointSpecs/Schemas/Bond/RequestData.bond
@@ -22,7 +22,7 @@ struct RequestData
     60: required string 	 responseCode;
     
     [Description("Indication of successfull or unsuccessfull call.")]
-    70: required bool 	 success;
+    70: required bool 	 success = true;
     
     [MaxStringLength("1024")]
     [Description("Source of the request. Examples are the instrumentation key of the caller or the ip address of the caller.")]

--- a/EndpointSpecs/Schemas/Docs/AvailabilityData.md
+++ b/EndpointSpecs/Schemas/Docs/AvailabilityData.md
@@ -48,9 +48,9 @@ Instances of AvailabilityData represent the result of executing an availability 
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     
@@ -58,7 +58,7 @@ Instances of AvailabilityData represent the result of executing an availability 
 
     Collection of custom measurements.
     
-    Max key length: "150"
+    Max key length: 150
     
     This field is optional.
     

--- a/EndpointSpecs/Schemas/Docs/ContextTagKeys.md
+++ b/EndpointSpecs/Schemas/Docs/ContextTagKeys.md
@@ -80,6 +80,36 @@
     
     This field is optional.
     
+1. **"ai.location.country"** : string
+
+    The country of the client device. If any of Country, Province, or City is specified, those values will be preferred over geolocation of the IP address field. Information in the location context fields is always about the end user. When telemetry is sent from a service, the location context is about the user that initiated the operation in the service.
+    
+    Max length: 256
+    
+    Default value: "ai.location.country"
+    
+    This field is optional.
+    
+1. **"ai.location.province"** : string
+
+    The province/state of the client device. If any of Country, Province, or City is specified, those values will be preferred over geolocation of the IP address field. Information in the location context fields is always about the end user. When telemetry is sent from a service, the location context is about the user that initiated the operation in the service.
+    
+    Max length: 256
+    
+    Default value: "ai.location.province"
+    
+    This field is optional.
+    
+1. **"ai.location.city"** : string
+
+    The city of the client device. If any of Country, Province, or City is specified, those values will be preferred over geolocation of the IP address field. Information in the location context fields is always about the end user. When telemetry is sent from a service, the location context is about the user that initiated the operation in the service.
+    
+    Max length: 256
+    
+    Default value: "ai.location.city"
+    
+    This field is optional.
+    
 1. **"ai.operation.id"** : string
 
     A unique identifier for the operation instance. The operation.id is created by either a request or a page view. All other telemetry sets this to the value for the containing request or page view. Operation.id is used for finding all the telemetry items for a specific operation instance.

--- a/EndpointSpecs/Schemas/Docs/Envelope.md
+++ b/EndpointSpecs/Schemas/Docs/Envelope.md
@@ -50,6 +50,12 @@ System variables for a telemetry item.
     
     This field is optional.
     
+1. **flags** : long
+
+    A collection of values bit-packed to represent how the event was processed. Currently represents whether IP address needs to be stripped out from event (set 0x200000) or should be preserved.
+    
+    This field is optional.
+    
 1. **tags** : IDictionary[string, string]
 
     Key/value collection of context properties. See ContextTagKeys for information on available properties.

--- a/EndpointSpecs/Schemas/Docs/EventData.md
+++ b/EndpointSpecs/Schemas/Docs/EventData.md
@@ -20,9 +20,9 @@ Instances of Event represent structured event records that can be grouped and se
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     
@@ -30,7 +30,7 @@ Instances of Event represent structured event records that can be grouped and se
 
     Collection of custom measurements.
     
-    Max key length: "150"
+    Max key length: 150
     
     This field is optional.
     

--- a/EndpointSpecs/Schemas/Docs/ExceptionData.md
+++ b/EndpointSpecs/Schemas/Docs/ExceptionData.md
@@ -122,9 +122,9 @@ An instance of Exception represents a handled or unhandled exception that occurr
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     
@@ -132,7 +132,7 @@ An instance of Exception represents a handled or unhandled exception that occurr
 
     Collection of custom measurements.
     
-    Max key length: "150"
+    Max key length: 150
     
     This field is optional.
     

--- a/EndpointSpecs/Schemas/Docs/MessageData.md
+++ b/EndpointSpecs/Schemas/Docs/MessageData.md
@@ -32,9 +32,17 @@ Instances of Message represent printf-like trace statements that are text-search
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
+    
+    This field is optional.
+    
+1. **measurements** : IDictionary[string, double]
+
+    Collection of custom measurements.
+    
+    Max key length: 150
     
     This field is optional.
     

--- a/EndpointSpecs/Schemas/Docs/MetricData.md
+++ b/EndpointSpecs/Schemas/Docs/MetricData.md
@@ -66,9 +66,9 @@ An instance of the Metric item is a list of measurements (single data points) an
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     

--- a/EndpointSpecs/Schemas/Docs/PageViewData.md
+++ b/EndpointSpecs/Schemas/Docs/PageViewData.md
@@ -20,9 +20,9 @@ An instance of PageView represents a generic action on a page like a button clic
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     
@@ -30,7 +30,7 @@ An instance of PageView represents a generic action on a page like a button clic
 
     Collection of custom measurements.
     
-    Max key length: "150"
+    Max key length: 150
     
     This field is optional.
     
@@ -47,6 +47,12 @@ An instance of PageView represents a generic action on a page like a button clic
     Request duration in format: DD.HH:MM:SS.MMMMMM. For a page view (PageViewData), this is the duration. For a page view with performance information (PageViewPerfData), this is the page load time. Must be less than 1000 days.
     
     This field is optional.
+    
+1. **referrerUri** : string
+
+    Fully qualified page URI or URL of the referring page; if unknown, leave blank
+    
+    Max length: 2048
     
 1. **id** : string
 

--- a/EndpointSpecs/Schemas/Docs/PageViewPerfData.md
+++ b/EndpointSpecs/Schemas/Docs/PageViewPerfData.md
@@ -20,9 +20,9 @@ An instance of PageViewPerf represents: a page view with no performance data, a 
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     
@@ -30,7 +30,7 @@ An instance of PageViewPerf represents: a page view with no performance data, a 
 
     Collection of custom measurements.
     
-    Max key length: "150"
+    Max key length: 150
     
     This field is optional.
     
@@ -47,6 +47,12 @@ An instance of PageViewPerf represents: a page view with no performance data, a 
     Request duration in format: DD.HH:MM:SS.MMMMMM. For a page view (PageViewData), this is the duration. For a page view with performance information (PageViewPerfData), this is the page load time. Must be less than 1000 days.
     
     This field is optional.
+    
+1. **referrerUri** : string
+
+    Fully qualified page URI or URL of the referring page; if unknown, leave blank
+    
+    Max length: 2048
     
 1. **id** : string
 

--- a/EndpointSpecs/Schemas/Docs/PageViewPerfData.md
+++ b/EndpointSpecs/Schemas/Docs/PageViewPerfData.md
@@ -48,6 +48,12 @@ An instance of PageViewPerf represents: a page view with no performance data, a 
     
     This field is optional.
     
+1. **id** : string
+
+    Identifier of a page view instance. Used for correlation between page view and other telemetry items.
+    
+    Max length: 128
+    
 1. **perfTotal** : string
 
     Performance total in TimeSpan 'G' (general long) format: d:hh:mm:ss.fffffff

--- a/EndpointSpecs/Schemas/Docs/RemoteDependencyData.md
+++ b/EndpointSpecs/Schemas/Docs/RemoteDependencyData.md
@@ -70,9 +70,9 @@ An instance of Remote Dependency represents an interaction of the monitored comp
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     
@@ -80,7 +80,7 @@ An instance of Remote Dependency represents an interaction of the monitored comp
 
     Collection of custom measurements.
     
-    Max key length: "150"
+    Max key length: 150
     
     This field is optional.
     

--- a/EndpointSpecs/Schemas/Docs/RequestData.md
+++ b/EndpointSpecs/Schemas/Docs/RequestData.md
@@ -28,6 +28,8 @@ An instance of Request represents completion of an external request to the appli
 
     Indication of successfull or unsuccessfull call.
     
+    Default value: true
+    
 1. **source** : string
 
     Source of the request. Examples are the instrumentation key of the caller or the ip address of the caller.
@@ -56,9 +58,9 @@ An instance of Request represents completion of an external request to the appli
 
     Collection of custom properties.
     
-    Max key length: "150"
+    Max key length: 150
     
-    Max value length: "8192"
+    Max value length: 8192
     
     This field is optional.
     
@@ -66,7 +68,7 @@ An instance of Request represents completion of an external request to the appli
 
     Collection of custom measurements.
     
-    Max key length: "150"
+    Max key length: 150
     
     This field is optional.
     


### PR DESCRIPTION
Regenerating schemas from the latest updates. Mostly to bring `flags` to envelope for #232 

Also fixes:

- https://github.com/Microsoft/ApplicationInsights-Home/issues/232
- https://github.com/Microsoft/ApplicationInsights-Home/issues/80
- https://github.com/Microsoft/ApplicationInsights-Home/issues/100
- https://github.com/Microsoft/ApplicationInsights-Home/issues/127
- #116