### PR TITLE
Update self diagnostics "Path" and "MaxSize" keywords

### DIFF
--- a/CrossSdkCollaboration/Self-Diagnostics.md
+++ b/CrossSdkCollaboration/Self-Diagnostics.md
@@ -69,7 +69,7 @@ The following values are optional. If any value cannot be parsed, the default va
     - Default Value: "%TEMP%"
     - If the provided value directory does not exist, the SDK needs to try to create it.
     - If the provided value is illegal for any reason, the SDK will fall back to the default value "%TEMP%".
-- [Optional] `MaxSize`
+- [Optional] `MaxSizeMB`
     - Value: Integer specifying max size in megabytes. A value of '0' will be interpreted as no limit.
     - Default: 0.
     - When a max size is exceeded, the SDK should close the file and start a new file.
@@ -85,7 +85,7 @@ The following values are optional. If any value cannot be parsed, the default va
 
 This format is proposed because multiple SDKs may have access to the same environment variable. This format will help users identify the program or process writing to this file.
 Both the process name and id are required because a single process may host many applications (for example: IIS's process is w3wp, but it can host multiple web applications on unique process ids).
-When a file exceeds the maxsize, the file will be closed and a new file will be created with a new timestamp.
+When a file exceeds the max size, the file will be closed and a new file will be created with a new timestamp.
 
 ##### File Contents
 
@@ -100,7 +100,7 @@ The file header should include
 
 
 ##### Full Example
-`Destination=File;Directory=C:/Temp;Level=verbose;MaxSize=50`
+`Destination=File;Directory=C:/Temp;Level=verbose;MaxSizeMB=50`
 
 ##### Minimum Valid Example
 `Destination=File`

--- a/CrossSdkCollaboration/Self-Diagnostics.md
+++ b/CrossSdkCollaboration/Self-Diagnostics.md
@@ -64,10 +64,10 @@ The SDK will revert back to the previous configuration if any of the following c
 All SDKs must support File logging to provide a basic and consistent supportability experience.
 The following values are optional. If any value cannot be parsed, the default value will be used instead.
 
-- [Optional] `Path`
+- [Optional] `Directory`
     - Value: The full path to a directory that the SDK will have write access. IMPORTANT: this field must be case sensitive
     - Default Value: "%TEMP%"
-    - If the provided value path does not exist, the SDK needs to try to create it.
+    - If the provided value directory does not exist, the SDK needs to try to create it.
     - If the provided value is illegal for any reason, the SDK will fall back to the default value "%TEMP%".
 - [Optional] `MaxSize`
     - Value: Integer specifying max size in megabytes. A value of '0' will be interpreted as no limit.
@@ -100,7 +100,7 @@ The file header should include
 
 
 ##### Full Example
-`Destination=File;Path=C:/Temp;Level=verbose;MaxSize=50`
+`Destination=File;Directory=C:/Temp;Level=verbose;MaxSize=50`
 
 ##### Minimum Valid Example
 `Destination=File`


### PR DESCRIPTION
Proposing two changes to the self diagnostics keywords to help make them more self-explanatory:

* Change "Path" keyword to "Directory", to make it clearer that the value should be a directory path, and not a file path.
* Change "MaxSize" keyword to "MaxSizeMB", to make it clearer that the value should be in MB.